### PR TITLE
Elasticsearch: Allow configuration for Server URL

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -49,3 +49,18 @@ From project root, you can run the following samples:
 > go run elasticsearch/*.go get_indices
 2021/01/30 18:54:54 Found 1 indices: [my_index]
 ```
+
+## Configuration
+
+Configure a new Elasticsearch client with custom addresses:
+
+```go
+es, err = elasticsearch.NewClient(elasticsearch.Config{
+    Addresses: []string{
+        "http://localhost:9200",
+        "http://localhost:9201",
+    },
+})
+```
+
+See https://github.com/elastic/go-elasticsearch#usage for more usage.


### PR DESCRIPTION
Before this PR, the code `get_indices.go` uses function `NewDefaultClient()` to create a new Elasticsearch client. This is great for demo purpose, but not suitable for read use-cases because we have to provide a valid URL. This URL is used to establish a connection between Elasticsearch Go client and Elasticsearch server, usually not running in local host. The default client method uses `http://localhost:9200` and environment variable `ELASTICSEARCH_URL` if present. But it will be insufficient if the environment variable is undefined or if we want to talk to multiple Elasticsearch servers in the Go code.

Knowing how to configure Elasticsearch Go client can also be useful for other settings, not only URL. There is a detailed documentation in  https://github.com/elastic/go-elasticsearch#usage.